### PR TITLE
Update Pandas to 1.3.0

### DIFF
--- a/mingw-w64-python-pandas/PKGBUILD
+++ b/mingw-w64-python-pandas/PKGBUILD
@@ -6,8 +6,8 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.0.5
-pkgrel=3
+pkgver=1.3.0
+pkgrel=1
 pkgdesc="Cross-section and time series data analysis toolkit (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64')
@@ -24,7 +24,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python-setuptools"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cython")
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/pandas-dev/${_realname}/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('69c5d920a0b2a9838e677f78f4dde506b95ea8e4d30da25859db6469ded84fa8')
+sha256sums=('c554e6c9cf2d5ea1aba5979cc837b3649539ced0e18ece186f055450c86622e2')
 
 prepare() {
   cp -a ${_realname}-${pkgver} ${_realname}-py-${pkgver}


### PR DESCRIPTION
Update Pandas to 1.3.0 - which is the latest version used by Arch. Tested build and the package for a couple on days - no issues to report.